### PR TITLE
Implementar decodificación de keystore en CI/CD

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -32,6 +32,16 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
+    - name: Decode keystore
+      run: |
+        if [ ! -z "${{ secrets.KEYSTORE }}" ]; then
+          echo "${{ secrets.KEYSTORE }}" | base64 --decode > ../keystore.jks
+          echo "Keystore decoded successfully"
+        else
+          echo "No keystore secret found, skipping release APK build"
+        fi
+      if: env.SIGNING_KEY_ALIAS != null
+
     - name: Build debug APK
       run: ./gradlew assembleDebug
 

--- a/signing.properties
+++ b/signing.properties
@@ -1,5 +1,6 @@
 # Signing configuration for release builds
-# Place your keystore file in the root directory of the project
+# For local development: Place your keystore file in the parent directory of the project
+# For CI/CD: The keystore will be decoded from the KEYSTORE secret environment variable
 # This file should NOT be committed to version control
 
 # Path to the keystore file (relative to project root)


### PR DESCRIPTION
- Agregar paso para decodificar keystore desde variable secreta KEYSTORE en base64
- Actualizar comentarios en signing.properties para contexto CI/CD
- El keystore se decodifica y guarda en ../keystore.jks antes del build
- Mejora la seguridad al usar secrets en lugar de archivos committeados