### PR TITLE
feat: confirmación manual, fix recordatorios, historial mensual, renombrar botón limpiar

### DIFF
--- a/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
@@ -49,6 +49,7 @@ class MainActivity : AppCompatActivity() {
     private val REMINDER_LAST_DAY_KEY = "reminder_last_day"
     private val BALANCE_NUMBER = "226"
     private val LAST_MONTH_KEY = "last_month"
+    private val LAST_BALANCE_KEY = "last_balance"
     private val MAX_MESSAGES = 50
     private val DEFAULT_DELAY = 2
 
@@ -70,6 +71,8 @@ class MainActivity : AppCompatActivity() {
     private lateinit var progressBar: ProgressBar
     private lateinit var sentMessagesTextView: TextView
     private lateinit var pendingConfirmationsTextView: TextView
+    private lateinit var manualConfirmButton: Button
+    private lateinit var historyButton: Button
     private lateinit var lastMonthDonationTextView: TextView
     private lateinit var totalDonationTextView: TextView
     private lateinit var todayDonationTextView: TextView
@@ -77,6 +80,7 @@ class MainActivity : AppCompatActivity() {
     private var sentThisSession = 0  // Messages sent this session
     private var confirmedThisSession = 0  // Confirmations received this session
     private val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+    private var isVerifyingBalance = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -90,6 +94,8 @@ class MainActivity : AppCompatActivity() {
         progressBar = findViewById(R.id.progressBar)
         sentMessagesTextView = findViewById(R.id.sentMessagesTextView)
         pendingConfirmationsTextView = findViewById(R.id.pendingConfirmationsTextView)
+        manualConfirmButton = findViewById(R.id.manualConfirmButton)
+        historyButton = findViewById(R.id.historyButton)
         lastMonthDonationTextView = findViewById(R.id.lastMonthDonationTextView)
         totalDonationTextView = findViewById(R.id.totalDonationTextView)
         todayDonationTextView = findViewById(R.id.todayDonationTextView)
@@ -189,6 +195,14 @@ class MainActivity : AppCompatActivity() {
 
         clearButton.setOnClickListener {
             clearEverything()
+        }
+
+        manualConfirmButton.setOnClickListener {
+            showManualConfirmationDialog()
+        }
+
+        historyButton.setOnClickListener {
+            showDonationHistory()
         }
 
         // Setup reminder checkbox listeners
@@ -416,14 +430,15 @@ class MainActivity : AppCompatActivity() {
             else -> 0xFFFF8F00.toInt() // Orange
         }
         pendingConfirmationsTextView.setTextColor(color)
+        manualConfirmButton.visibility = if (pending > 0) android.view.View.VISIBLE else android.view.View.GONE
     }
 
     private fun clearEverything() {
         // Show confirmation dialog
         val dialog = android.app.AlertDialog.Builder(this)
-        dialog.setTitle("Confirmar")
-        dialog.setMessage("¿Está seguro que desea limpiar todos los datos?")
-        dialog.setPositiveButton("Sí") { _, _ ->
+        dialog.setTitle("Reiniciar contadores de sesión")
+        dialog.setMessage("Esto reiniciará los contadores de mensajes enviados en esta sesión y limpiará el saldo mostrado.\n\n⚠️ El historial de donaciones NO se borrará.")
+        dialog.setPositiveButton("Sí, reiniciar") { _, _ ->
             // Clear response count
             val sharedPreferences = getSharedPreferences("donation_prefs", Context.MODE_PRIVATE)
             sharedPreferences.edit().apply {
@@ -451,7 +466,7 @@ class MainActivity : AppCompatActivity() {
             // Hide progress UI
             showProgressUI(false)
             
-            Toast.makeText(this, "Campos limpiados (historial de donaciones preservado)", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, "Contadores de sesión reiniciados (historial preservado)", Toast.LENGTH_SHORT).show()
         }
         dialog.setNegativeButton("No", null)
         dialog.show()
@@ -501,31 +516,31 @@ class MainActivity : AppCompatActivity() {
     private fun updateReminders(showToast: Boolean = false) {
         val alarmManager = getSystemService(ALARM_SERVICE) as AlarmManager
         
-        // Cancel all existing reminders first
-        for (requestCode in 0..3) {
+        // Cancel all existing reminders (using daysBeforeEnd as requestCode: 0, 1, 3, 4)
+        for (requestCode in listOf(0, 1, 3, 4)) {
             val intent = Intent(this, ReminderReceiver::class.java)
             val pendingIntent = PendingIntent.getBroadcast(
                 this, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
             alarmManager.cancel(pendingIntent)
         }
         
-        // Schedule reminders based on checkbox states
+        // Schedule reminders based on checkbox states (requestCode = daysBeforeEnd)
         val reminder4Days = sharedPreferences.getBoolean(REMINDER_4_DAYS_KEY, false)
         val reminder3Days = sharedPreferences.getBoolean(REMINDER_3_DAYS_KEY, false)
         val reminderPenultimate = sharedPreferences.getBoolean(REMINDER_PENULTIMATE_KEY, false)
         val reminderLastDay = sharedPreferences.getBoolean(REMINDER_LAST_DAY_KEY, false)
         
         if (reminder4Days) {
-            scheduleReminder(4, 0) // 4 days before end of month, request code 0
+            scheduleReminder(4, 4)
         }
         if (reminder3Days) {
-            scheduleReminder(3, 1) // 3 days before end of month, request code 1
+            scheduleReminder(3, 3)
         }
         if (reminderPenultimate) {
-            scheduleReminder(1, 2) // Penultimate day (1 day before last), request code 2
+            scheduleReminder(1, 1)
         }
         if (reminderLastDay) {
-            scheduleReminder(0, 3) // Last day of month, request code 3
+            scheduleReminder(0, 0)
         }
         
         val anyEnabled = reminder4Days || reminder3Days || reminderPenultimate || reminderLastDay
@@ -541,25 +556,30 @@ class MainActivity : AppCompatActivity() {
         val pendingIntent = PendingIntent.getBroadcast(
             this, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
 
-        // Calculate the target day
+        // Calculate the target day in the current month
         val calendar = Calendar.getInstance()
         val lastDayOfMonth = calendar.getActualMaximum(Calendar.DAY_OF_MONTH)
         val targetDay = lastDayOfMonth - daysBeforeEnd
         
         calendar.set(Calendar.DAY_OF_MONTH, targetDay)
-        // Set time to 20:00 (8 PM)
         calendar.set(Calendar.HOUR_OF_DAY, 20)
         calendar.set(Calendar.MINUTE, 0)
         calendar.set(Calendar.SECOND, 0)
+        calendar.set(Calendar.MILLISECOND, 0)
 
-        // If the time is already past, schedule for next month
+        // If the time already passed this month, schedule for next month
         if (calendar.timeInMillis <= System.currentTimeMillis()) {
             calendar.add(Calendar.MONTH, 1)
             val nextMonthLastDay = calendar.getActualMaximum(Calendar.DAY_OF_MONTH)
             calendar.set(Calendar.DAY_OF_MONTH, nextMonthLastDay - daysBeforeEnd)
         }
 
-        alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.timeInMillis, pendingIntent)
+        // Use setExactAndAllowWhileIdle to fire even in Doze mode (Android 6+)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, calendar.timeInMillis, pendingIntent)
+        } else {
+            alarmManager.setExact(AlarmManager.RTC_WAKEUP, calendar.timeInMillis, pendingIntent)
+        }
     }
     
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
@@ -628,7 +648,11 @@ class MainActivity : AppCompatActivity() {
                 val pendingIntent = PendingIntent.getBroadcast(
                     context, daysBeforeEnd, newIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
 
-                alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.timeInMillis, pendingIntent)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, calendar.timeInMillis, pendingIntent)
+                } else {
+                    alarmManager.setExact(AlarmManager.RTC_WAKEUP, calendar.timeInMillis, pendingIntent)
+                }
             }
         }
     }
@@ -757,6 +781,34 @@ class MainActivity : AppCompatActivity() {
                 val balance = numericPart.toDouble()
                 val calculatedCount = (balance / 10).toInt()
                 val numericPartFinal = numericPart
+
+                // Save the current balance for future verification comparisons
+                val previousBalance = sharedPreferences.getFloat(LAST_BALANCE_KEY, -1f)
+                sharedPreferences.edit().putFloat(LAST_BALANCE_KEY, balance.toFloat()).apply()
+
+                // If in verification mode, compare with previous balance to detect donations
+                if (isVerifyingBalance) {
+                    isVerifyingBalance = false
+                    if (previousBalance >= 0f) {
+                        val diff = previousBalance - balance.toFloat()
+                        val donatedMessages = (diff / 10).toInt()
+                        runOnUiThread {
+                            if (diff > 0) {
+                                android.app.AlertDialog.Builder(this)
+                                    .setTitle("✅ Donaciones detectadas por saldo")
+                                    .setMessage("Saldo anterior: ${"%.0f".format(previousBalance)}$\nSaldo actual: ${"%.0f".format(balance)}$\n\nDiferencia: ${"%.0f".format(diff)}$ = $donatedMessages mensajes\n\n¿Confirmar estas donaciones en el historial?")
+                                    .setPositiveButton("Confirmar $donatedMessages mensajes") { _, _ ->
+                                        manuallyConfirmPending(donatedMessages)
+                                    }
+                                    .setNegativeButton("Cancelar", null)
+                                    .show()
+                            } else {
+                                Toast.makeText(this, "ℹ️ No se detectaron donaciones por diferencia de saldo", Toast.LENGTH_LONG).show()
+                            }
+                        }
+                        return
+                    }
+                }
                 
                 // Get already sent messages from database asynchronously
                 CoroutineScope(Dispatchers.IO).launch {
@@ -803,6 +855,94 @@ class MainActivity : AppCompatActivity() {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    private fun showManualConfirmationDialog() {
+        val pending = (sentThisSession - confirmedThisSession).coerceAtLeast(0)
+        val hasLastBalance = sharedPreferences.getFloat(LAST_BALANCE_KEY, -1f) >= 0f
+
+        val dialog = android.app.AlertDialog.Builder(this)
+        dialog.setTitle("Confirmación manual")
+        dialog.setMessage("Hay $pending mensaje(s) pendientes de confirmar.\n\nPodés confirmarlos manualmente o verificar por diferencia de saldo.")
+
+        dialog.setPositiveButton("✅ Confirmar $pending donaciones") { _, _ ->
+            manuallyConfirmPending(pending)
+        }
+
+        dialog.setNeutralButton("📊 Verificar por saldo") { _, _ ->
+            startBalanceVerification()
+        }
+
+        dialog.setNegativeButton("Cancelar", null)
+
+        val alertDialog = dialog.create()
+        alertDialog.show()
+
+        // Disable "Verificar por saldo" if no previous balance is stored
+        alertDialog.getButton(android.app.AlertDialog.BUTTON_NEUTRAL)?.isEnabled = hasLastBalance
+        if (!hasLastBalance) {
+            alertDialog.getButton(android.app.AlertDialog.BUTTON_NEUTRAL)?.text = "📊 Verificar por saldo (sin saldo previo)"
+        }
+    }
+
+    private fun manuallyConfirmPending(count: Int) {
+        if (count <= 0) return
+        val amountPesos = count * 10
+        val today = dateFormat.format(Calendar.getInstance().time)
+        CoroutineScope(Dispatchers.IO).launch {
+            val existing = database.donationDao().getByDate(today)
+            if (existing != null) {
+                database.donationDao().addToDate(today, amountPesos)
+            } else {
+                database.donationDao().insertOrUpdate(
+                    uy.roar.donadorautomatico.data.DonationRecord(today, amountPesos)
+                )
+            }
+            withContext(Dispatchers.Main) {
+                confirmedThisSession += count
+                updatePendingConfirmations()
+                refreshDonationStats()
+                Toast.makeText(this@MainActivity, "✅ $count donación(es) confirmadas manualmente (+$${amountPesos})", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun startBalanceVerification() {
+        if (checkAndRequestPermissions()) {
+            isVerifyingBalance = true
+            sendBalanceCheck()
+            Toast.makeText(this, "📊 Consultando saldo para verificar donaciones...", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun showDonationHistory() {
+        CoroutineScope(Dispatchers.IO).launch {
+            val monthlyTotals = database.donationDao().getMonthlyTotals()
+            withContext(Dispatchers.Main) {
+                if (monthlyTotals.isEmpty()) {
+                    Toast.makeText(this@MainActivity, "No hay donaciones registradas aún", Toast.LENGTH_SHORT).show()
+                    return@withContext
+                }
+                val sb = StringBuilder()
+                for (entry in monthlyTotals) {
+                    sb.appendLine("${entry.month}  →  $${entry.total}")
+                }
+                val scrollView = android.widget.ScrollView(this@MainActivity)
+                val textView = TextView(this@MainActivity).apply {
+                    text = sb.toString().trimEnd()
+                    textSize = 15f
+                    setTextColor(0xFF2E7D32.toInt())
+                    typeface = android.graphics.Typeface.MONOSPACE
+                    setPadding(48, 24, 48, 24)
+                }
+                scrollView.addView(textView)
+                android.app.AlertDialog.Builder(this@MainActivity)
+                    .setTitle("📅 Historial de donaciones")
+                    .setView(scrollView)
+                    .setPositiveButton("Cerrar", null)
+                    .show()
             }
         }
     }

--- a/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
@@ -13,6 +13,8 @@ import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.provider.Telephony
 import android.telephony.SmsManager
 import android.telephony.SmsMessage
@@ -81,6 +83,11 @@ class MainActivity : AppCompatActivity() {
     private var confirmedThisSession = 0  // Confirmations received this session
     private val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
     private var isVerifyingBalance = false
+    private val verificationTimeoutHandler = Handler(Looper.getMainLooper())
+    private val verificationTimeoutRunnable = Runnable {
+        isVerifyingBalance = false
+        Toast.makeText(this, "⏱️ No se recibió respuesta de saldo para la verificación", Toast.LENGTH_LONG).show()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -242,8 +249,8 @@ class MainActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        // Unregister receiver when activity is destroyed
         unregisterReceiver(smsReceiver)
+        verificationTimeoutHandler.removeCallbacks(verificationTimeoutRunnable)
     }
 
     private fun checkMonthChange() {
@@ -516,8 +523,8 @@ class MainActivity : AppCompatActivity() {
     private fun updateReminders(showToast: Boolean = false) {
         val alarmManager = getSystemService(ALARM_SERVICE) as AlarmManager
         
-        // Cancel all existing reminders (using daysBeforeEnd as requestCode: 0, 1, 3, 4)
-        for (requestCode in listOf(0, 1, 3, 4)) {
+        // Cancel all existing reminders (current codes: 0,1,3,4; include 2 for migration from old scheme)
+        for (requestCode in listOf(0, 1, 2, 3, 4)) {
             val intent = Intent(this, ReminderReceiver::class.java)
             val pendingIntent = PendingIntent.getBroadcast(
                 this, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
@@ -786,8 +793,9 @@ class MainActivity : AppCompatActivity() {
                 val previousBalance = sharedPreferences.getFloat(LAST_BALANCE_KEY, -1f)
                 sharedPreferences.edit().putFloat(LAST_BALANCE_KEY, balance.toFloat()).apply()
 
-                // If in verification mode, compare with previous balance to detect donations
+                // If in verification mode, cancel the timeout and compare with previous balance
                 if (isVerifyingBalance) {
+                    verificationTimeoutHandler.removeCallbacks(verificationTimeoutRunnable)
                     isVerifyingBalance = false
                     if (previousBalance >= 0f) {
                         val diff = previousBalance - balance.toFloat()
@@ -796,7 +804,7 @@ class MainActivity : AppCompatActivity() {
                             if (diff > 0) {
                                 android.app.AlertDialog.Builder(this)
                                     .setTitle("✅ Donaciones detectadas por saldo")
-                                    .setMessage("Saldo anterior: ${"%.0f".format(previousBalance)}$\nSaldo actual: ${"%.0f".format(balance)}$\n\nDiferencia: ${"%.0f".format(diff)}$ = $donatedMessages mensajes\n\n¿Confirmar estas donaciones en el historial?")
+                                    .setMessage("Saldo anterior: ${"%.0f".format(previousBalance)}\$\nSaldo actual: ${"%.0f".format(balance)}\$\n\nDiferencia: ${"%.0f".format(diff)}\$ = $donatedMessages mensajes\n\n¿Confirmar estas donaciones en el historial?")
                                     .setPositiveButton("Confirmar $donatedMessages mensajes") { _, _ ->
                                         manuallyConfirmPending(donatedMessages)
                                     }
@@ -855,7 +863,16 @@ class MainActivity : AppCompatActivity() {
                         }
                     }
                 }
+            } else if (isVerifyingBalance) {
+                // Balance message arrived but couldn't be parsed — cancel verification mode
+                verificationTimeoutHandler.removeCallbacks(verificationTimeoutRunnable)
+                isVerifyingBalance = false
+                runOnUiThread {
+                    Toast.makeText(this, "⚠️ No se pudo leer el saldo para verificar donaciones", Toast.LENGTH_LONG).show()
+                }
             }
+        } else if (isVerifyingBalance) {
+            // Any non-balance message from 226 — don't reset the flag, keep waiting
         }
     }
 
@@ -868,7 +885,13 @@ class MainActivity : AppCompatActivity() {
         dialog.setMessage("Hay $pending mensaje(s) pendientes de confirmar.\n\nPodés confirmarlos manualmente o verificar por diferencia de saldo.")
 
         dialog.setPositiveButton("✅ Confirmar $pending donaciones") { _, _ ->
-            manuallyConfirmPending(pending)
+            // Recalculate at click time in case confirmations arrived while dialog was open
+            val currentPending = (sentThisSession - confirmedThisSession).coerceAtLeast(0)
+            if (currentPending > 0) {
+                manuallyConfirmPending(currentPending)
+            } else {
+                Toast.makeText(this, "No hay donaciones pendientes para confirmar", Toast.LENGTH_SHORT).show()
+            }
         }
 
         dialog.setNeutralButton("📊 Verificar por saldo") { _, _ ->
@@ -904,16 +927,19 @@ class MainActivity : AppCompatActivity() {
                 confirmedThisSession += count
                 updatePendingConfirmations()
                 refreshDonationStats()
-                Toast.makeText(this@MainActivity, "✅ $count donación(es) confirmadas manualmente (+$${amountPesos})", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this@MainActivity, "✅ $count donación(es) confirmadas manualmente (+\$${amountPesos})", Toast.LENGTH_SHORT).show()
             }
         }
     }
 
     private fun startBalanceVerification() {
+        // Set flag before requesting permissions so it persists through the permission flow
+        isVerifyingBalance = true
         if (checkAndRequestPermissions()) {
-            isVerifyingBalance = true
             sendBalanceCheck()
             Toast.makeText(this, "📊 Consultando saldo para verificar donaciones...", Toast.LENGTH_SHORT).show()
+            // Auto-cancel verification mode after 30 seconds if no response arrives
+            verificationTimeoutHandler.postDelayed(verificationTimeoutRunnable, 30_000L)
         }
     }
 
@@ -927,7 +953,7 @@ class MainActivity : AppCompatActivity() {
                 }
                 val sb = StringBuilder()
                 for (entry in monthlyTotals) {
-                    sb.appendLine("${entry.month}  →  $${entry.total}")
+                    sb.appendLine("${entry.month}  →  ${entry.total}\$")
                 }
                 val scrollView = android.widget.ScrollView(this@MainActivity)
                 val textView = TextView(this@MainActivity).apply {

--- a/app/src/main/java/uy/roar/donadorautomatico/data/DonationDao.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/data/DonationDao.kt
@@ -8,7 +8,7 @@ import androidx.room.Query
 
 data class MonthlyTotal(
     @ColumnInfo(name = "month") val month: String,
-    @ColumnInfo(name = "total") val total: Int
+    @ColumnInfo(name = "total") val total: Long
 )
 
 @Dao

--- a/app/src/main/java/uy/roar/donadorautomatico/data/DonationDao.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/data/DonationDao.kt
@@ -1,9 +1,15 @@
 package uy.roar.donadorautomatico.data
 
+import androidx.room.ColumnInfo
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+
+data class MonthlyTotal(
+    @ColumnInfo(name = "month") val month: String,
+    @ColumnInfo(name = "total") val total: Int
+)
 
 @Dao
 interface DonationDao {
@@ -25,4 +31,7 @@ interface DonationDao {
     
     @Query("UPDATE donation_records SET amount = amount + :amount WHERE date = :date")
     suspend fun addToDate(date: String, amount: Int): Int
+
+    @Query("SELECT substr(date, 1, 7) as month, SUM(amount) as total FROM donation_records GROUP BY substr(date, 1, 7) ORDER BY month DESC")
+    suspend fun getMonthlyTotals(): List<MonthlyTotal>
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -104,13 +104,14 @@
         <Button
             android:id="@+id/historyButton"
             android:layout_width="wrap_content"
-            android:layout_height="32dp"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
             android:text="📅 Ver historial"
             android:textSize="11sp"
             android:textColor="#2E7D32"
             android:background="@android:color/transparent"
-            android:paddingStart="0dp"
-            android:paddingEnd="0dp"
+            android:paddingStart="8dp"
+            android:paddingEnd="8dp"
             android:layout_marginTop="2dp"/>
 
         <View
@@ -156,13 +157,16 @@
             <Button
                 android:id="@+id/manualConfirmButton"
                 android:layout_width="wrap_content"
-                android:layout_height="36dp"
+                android:layout_height="wrap_content"
+                android:minHeight="48dp"
                 android:text="✋ Confirmar"
                 android:textSize="11sp"
                 android:textColor="@android:color/white"
                 android:background="@drawable/button_secondary"
                 android:paddingStart="8dp"
                 android:paddingEnd="8dp"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
                 android:visibility="gone"/>
 
         </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -101,6 +101,18 @@
             android:textColor="#388E3C"
             android:layout_marginTop="4dp"/>
 
+        <Button
+            android:id="@+id/historyButton"
+            android:layout_width="wrap_content"
+            android:layout_height="32dp"
+            android:text="📅 Ver historial"
+            android:textSize="11sp"
+            android:textColor="#2E7D32"
+            android:background="@android:color/transparent"
+            android:paddingStart="0dp"
+            android:paddingEnd="0dp"
+            android:layout_marginTop="2dp"/>
+
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
@@ -125,14 +137,35 @@
             android:textColor="#388E3C"
             android:layout_marginTop="4dp"/>
 
-        <TextView
-            android:id="@+id/pendingConfirmationsTextView"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Pendientes de confirmar: 0"
-            android:textSize="14sp"
-            android:textColor="#FF8F00"
-            android:layout_marginTop="4dp"/>
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginTop="4dp">
+
+            <TextView
+                android:id="@+id/pendingConfirmationsTextView"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Pendientes de confirmar: 0"
+                android:textSize="14sp"
+                android:textColor="#FF8F00"/>
+
+            <Button
+                android:id="@+id/manualConfirmButton"
+                android:layout_width="wrap_content"
+                android:layout_height="36dp"
+                android:text="✋ Confirmar"
+                android:textSize="11sp"
+                android:textColor="@android:color/white"
+                android:background="@drawable/button_secondary"
+                android:paddingStart="8dp"
+                android:paddingEnd="8dp"
+                android:visibility="gone"/>
+
+        </LinearLayout>
 
     </LinearLayout>
 
@@ -359,10 +392,10 @@
         android:id="@+id/clearButton"
         android:layout_width="match_parent"
         android:layout_height="56dp"
-        android:text="Limpiar Todo"
+        android:text="🔄 Reiniciar contadores de sesión"
         android:textColor="@android:color/white"
         android:textStyle="bold"
-        android:textSize="16sp"
+        android:textSize="14sp"
         android:background="@drawable/button_danger"
         android:layout_marginTop="24dp"
         android:layout_marginBottom="32dp" />


### PR DESCRIPTION
## Cambios incluidos

### ✋ Confirmación manual de donaciones
- Nuevo botón **"✋ Confirmar"** al lado de "Pendientes de confirmar" (aparece solo cuando hay pendientes)
- Al presionarlo muestra un diálogo con dos opciones:
  - **"✅ Confirmar N donaciones"**: agrega los pendientes directamente al historial (N × $10) sin necesitar respuesta del servidor
  - **"📊 Verificar por saldo"**: deshabilitado hasta que se haya consultado el saldo al menos una vez; envía consulta de saldo y calcula donaciones por diferencia (ej: 1300 → 800 = $500 = 50 mensajes), luego ofrece confirmarlas
- El saldo consultado se guarda automáticamente en SharedPrefs para poder hacer la comparación futura

### 🔔 Fix de recordatorios (AlarmManager)
- **Bug corregido**: `requestCode` era inconsistente entre `scheduleReminder()` (usaba 0,1,2,3) y `ReminderReceiver` (usaba `daysBeforeEnd` = 0,1,3,4) → los alarms no se podían cancelar ni reprogramar correctamente
- Unificado a `requestCode = daysBeforeEnd` en todos lados
- Cambiado `alarmManager.set()` → `setExactAndAllowWhileIdle()` para funcionar correctamente en Doze mode (Android 6+), lo que debería resolver el problema de recordatorios que no se disparaban

### 📅 Historial de donaciones por mes
- Nuevo botón **"�� Ver historial"** debajo de "Total histórico"
- Muestra un popup con tabla mes a mes: `2026-03 → $310` / `2026-02 → $400` ...
- Nueva query en `DonationDao` que agrupa por mes (`GROUP BY substr(date, 1, 7)`)

### 🔄 Renombrar "Limpiar Todo"
- Botón ahora dice **"🔄 Reiniciar contadores de sesión"**
- Diálogo actualizado: aclara explícitamente que **solo resetea los contadores de esta sesión** y que el historial de donaciones NO se borra

## Archivos modificados
- `DonationDao.kt`: nueva data class `MonthlyTotal` + query de historial mensual
- `activity_main.xml`: botón de confirmación manual, botón de historial, renombrar botón limpiar
- `MainActivity.kt`: toda la lógica de los 4 features