### PR TITLE
fix: corregir doble conteo en verificación de donaciones por saldo

### DIFF
--- a/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
@@ -52,6 +52,7 @@ class MainActivity : AppCompatActivity() {
     private val BALANCE_NUMBER = "226"
     private val LAST_MONTH_KEY = "last_month"
     private val LAST_BALANCE_KEY = "last_balance"
+    private val CONFIRMED_AT_BASELINE_KEY = "confirmed_at_baseline"
     private val MAX_MESSAGES = 50
     private val DEFAULT_DELAY = 2
 
@@ -150,6 +151,9 @@ class MainActivity : AppCompatActivity() {
 
         // Initialize shared preferences
         sharedPreferences = getSharedPreferences(PREF_NAME, MODE_PRIVATE)
+
+        // Restore persisted baseline snapshot so it stays in sync with LAST_BALANCE_KEY across recreation
+        confirmedAtBaselineSave = sharedPreferences.getInt(CONFIRMED_AT_BASELINE_KEY, 0)
 
         // Check for month change and ask user if they want to reset counters
         checkMonthChange()
@@ -291,6 +295,10 @@ class MainActivity : AppCompatActivity() {
         sentThisSession = 0
         confirmedThisSession = 0
         confirmedAtBaselineSave = 0
+        sharedPreferences.edit()
+            .remove(LAST_BALANCE_KEY)
+            .remove(CONFIRMED_AT_BASELINE_KEY)
+            .apply()
         refreshDonationStats()
         updatePendingConfirmations()
         Toast.makeText(this, "Contadores reiniciados", Toast.LENGTH_SHORT).show()
@@ -467,6 +475,10 @@ class MainActivity : AppCompatActivity() {
             sentThisSession = 0
             confirmedThisSession = 0
             confirmedAtBaselineSave = 0
+            sharedPreferences.edit()
+                .remove(LAST_BALANCE_KEY)
+                .remove(CONFIRMED_AT_BASELINE_KEY)
+                .apply()
             updatePendingConfirmations()
             refreshDonationStats()
             
@@ -792,7 +804,10 @@ class MainActivity : AppCompatActivity() {
                 // Save the current balance for future verification comparisons (only when establishing a new baseline, not during verification)
                 val previousBalance = sharedPreferences.getFloat(LAST_BALANCE_KEY, -1f)
                 if (!isVerifyingBalance) {
-                    sharedPreferences.edit().putFloat(LAST_BALANCE_KEY, balance.toFloat()).apply()
+                    sharedPreferences.edit()
+                        .putFloat(LAST_BALANCE_KEY, balance.toFloat())
+                        .putInt(CONFIRMED_AT_BASELINE_KEY, confirmedThisSession)
+                        .apply()
                     confirmedAtBaselineSave = confirmedThisSession
                 }
 
@@ -815,8 +830,12 @@ class MainActivity : AppCompatActivity() {
                                     .setMessage("Saldo anterior: ${"%.0f".format(previousBalance)}\$\nSaldo actual: ${"%.0f".format(balance)}\$\n\nDiferencia: ${"%.0f".format(diff)}\$ = $donatedMessages mensajes$alreadyConfirmedInfo\n\n¿Confirmar las donaciones pendientes en el historial?")
                                     .setPositiveButton("Confirmar $pendingToConfirm mensajes") { _, _ ->
                                         // Advance baseline so the same diff isn't re-offered after restart
-                                        sharedPreferences.edit().putFloat(LAST_BALANCE_KEY, balance.toFloat()).apply()
-                                        confirmedAtBaselineSave = confirmedThisSession + pendingToConfirm
+                                        val newBaseline = confirmedThisSession + pendingToConfirm
+                                        sharedPreferences.edit()
+                                            .putFloat(LAST_BALANCE_KEY, balance.toFloat())
+                                            .putInt(CONFIRMED_AT_BASELINE_KEY, newBaseline)
+                                            .apply()
+                                        confirmedAtBaselineSave = newBaseline
                                         manuallyConfirmPending(pendingToConfirm)
                                     }
                                     .setNegativeButton("Cancelar", null)

--- a/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
@@ -55,7 +55,6 @@ class MainActivity : AppCompatActivity() {
     private val CONFIRMED_AT_BASELINE_KEY = "confirmed_at_baseline"
     private val CONFIRMED_THIS_SESSION_KEY = "confirmed_this_session"
     private val SENT_THIS_SESSION_KEY = "sent_this_session"
-    private val MANUALLY_CLAIMED_KEY = "manually_claimed"
     private val MAX_MESSAGES = 50
     private val DEFAULT_DELAY = 2
 
@@ -86,7 +85,6 @@ class MainActivity : AppCompatActivity() {
     private var sentThisSession = 0  // Messages sent this session
     private var confirmedThisSession = 0  // Confirmations received this session
     private var confirmedAtBaselineSave = 0  // Snapshot of confirmedThisSession when baseline balance was saved
-    private var manuallyClaimedCount = 0  // Pending slots reserved by manual confirmation, to discard matching late auto-SMSs
     private val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
     private var isVerifyingBalance = false
     private val verificationTimeoutHandler = Handler(Looper.getMainLooper())
@@ -160,7 +158,6 @@ class MainActivity : AppCompatActivity() {
         confirmedAtBaselineSave = sharedPreferences.getInt(CONFIRMED_AT_BASELINE_KEY, 0)
         confirmedThisSession = sharedPreferences.getInt(CONFIRMED_THIS_SESSION_KEY, 0)
         sentThisSession = sharedPreferences.getInt(SENT_THIS_SESSION_KEY, 0)
-        manuallyClaimedCount = sharedPreferences.getInt(MANUALLY_CLAIMED_KEY, 0)
 
         // Check for month change and ask user if they want to reset counters
         checkMonthChange()
@@ -302,13 +299,11 @@ class MainActivity : AppCompatActivity() {
         sentThisSession = 0
         confirmedThisSession = 0
         confirmedAtBaselineSave = 0
-        manuallyClaimedCount = 0
         sharedPreferences.edit()
             .remove(LAST_BALANCE_KEY)
             .remove(CONFIRMED_AT_BASELINE_KEY)
             .putInt(CONFIRMED_THIS_SESSION_KEY, 0)
             .putInt(SENT_THIS_SESSION_KEY, 0)
-            .putInt(MANUALLY_CLAIMED_KEY, 0)
             .apply()
         refreshDonationStats()
         updatePendingConfirmations()
@@ -488,13 +483,11 @@ class MainActivity : AppCompatActivity() {
             sentThisSession = 0
             confirmedThisSession = 0
             confirmedAtBaselineSave = 0
-            manuallyClaimedCount = 0
             sharedPreferences.edit()
                 .remove(LAST_BALANCE_KEY)
                 .remove(CONFIRMED_AT_BASELINE_KEY)
                 .putInt(CONFIRMED_THIS_SESSION_KEY, 0)
                 .putInt(SENT_THIS_SESSION_KEY, 0)
-                .putInt(MANUALLY_CLAIMED_KEY, 0)
                 .apply()
             updatePendingConfirmations()
             refreshDonationStats()
@@ -738,15 +731,11 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun addDonation(amount: Int) {
-        // If there are pending manual claims, this is a late auto-SMS for a batch already manually
-        // confirmed. Consume the claim and skip the DB write to avoid double-counting.
-        if (manuallyClaimedCount > 0) {
-            manuallyClaimedCount--
-            sharedPreferences.edit().putInt(MANUALLY_CLAIMED_KEY, manuallyClaimedCount).apply()
-            // confirmedThisSession was already pre-incremented by manuallyConfirmPending; no further action needed.
-            updatePendingConfirmations()
-            return
-        }
+        // NOTE: Late auto-confirmation SMSs that arrive after a manual confirmation of the same
+        // donation will be recorded again here. Preventing this reliably requires per-message
+        // tracking (unique IDs per SMS), which the carrier does not provide. This is a known
+        // limitation; the balance-verification fix (confirmedSinceBaseline) already prevents the
+        // primary double-count from the verification flow itself.
         val today = dateFormat.format(Calendar.getInstance().time)
         // Increment session confirmation counter and persist so it survives activity recreation
         confirmedThisSession++
@@ -976,13 +965,11 @@ class MainActivity : AppCompatActivity() {
 
     private fun manuallyConfirmPending(count: Int) {
         if (count <= 0) return
-        // Claim the pending count synchronously: pre-increment confirmedThisSession and register
-        // manual claims so that matching late auto-confirmation SMSs are discarded by addDonation().
+        // Claim the pending count synchronously on the Main thread before the async DB write,
+        // so an automatic confirmation SMS arriving in the interim cannot cause double-counting.
         confirmedThisSession += count
-        manuallyClaimedCount += count
         sharedPreferences.edit()
             .putInt(CONFIRMED_THIS_SESSION_KEY, confirmedThisSession)
-            .putInt(MANUALLY_CLAIMED_KEY, manuallyClaimedCount)
             .apply()
         updatePendingConfirmations()
         val amountPesos = count * 10

--- a/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
@@ -54,6 +54,7 @@ class MainActivity : AppCompatActivity() {
     private val LAST_BALANCE_KEY = "last_balance"
     private val CONFIRMED_AT_BASELINE_KEY = "confirmed_at_baseline"
     private val CONFIRMED_THIS_SESSION_KEY = "confirmed_this_session"
+    private val SENT_THIS_SESSION_KEY = "sent_this_session"
     private val MAX_MESSAGES = 50
     private val DEFAULT_DELAY = 2
 
@@ -156,6 +157,7 @@ class MainActivity : AppCompatActivity() {
         // Restore persisted baseline snapshot so it stays in sync with LAST_BALANCE_KEY across recreation
         confirmedAtBaselineSave = sharedPreferences.getInt(CONFIRMED_AT_BASELINE_KEY, 0)
         confirmedThisSession = sharedPreferences.getInt(CONFIRMED_THIS_SESSION_KEY, 0)
+        sentThisSession = sharedPreferences.getInt(SENT_THIS_SESSION_KEY, 0)
 
         // Check for month change and ask user if they want to reset counters
         checkMonthChange()
@@ -301,6 +303,7 @@ class MainActivity : AppCompatActivity() {
             .remove(LAST_BALANCE_KEY)
             .remove(CONFIRMED_AT_BASELINE_KEY)
             .putInt(CONFIRMED_THIS_SESSION_KEY, 0)
+            .putInt(SENT_THIS_SESSION_KEY, 0)
             .apply()
         refreshDonationStats()
         updatePendingConfirmations()
@@ -371,6 +374,7 @@ class MainActivity : AppCompatActivity() {
                 
                 // Increment BEFORE send attempt - counts as "attempted"
                 sentThisSession++
+                sharedPreferences.edit().putInt(SENT_THIS_SESSION_KEY, sentThisSession).apply()
                 updatePendingConfirmations()
                 refreshDonationStats()
                 
@@ -412,6 +416,7 @@ class MainActivity : AppCompatActivity() {
                 
                 // Increment BEFORE send attempt - counts as "attempted"
                 sentThisSession++
+                sharedPreferences.edit().putInt(SENT_THIS_SESSION_KEY, sentThisSession).apply()
                 updatePendingConfirmations()
                 refreshDonationStats()
                 
@@ -482,6 +487,7 @@ class MainActivity : AppCompatActivity() {
                 .remove(LAST_BALANCE_KEY)
                 .remove(CONFIRMED_AT_BASELINE_KEY)
                 .putInt(CONFIRMED_THIS_SESSION_KEY, 0)
+                .putInt(SENT_THIS_SESSION_KEY, 0)
                 .apply()
             updatePendingConfirmations()
             refreshDonationStats()

--- a/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
@@ -55,6 +55,7 @@ class MainActivity : AppCompatActivity() {
     private val CONFIRMED_AT_BASELINE_KEY = "confirmed_at_baseline"
     private val CONFIRMED_THIS_SESSION_KEY = "confirmed_this_session"
     private val SENT_THIS_SESSION_KEY = "sent_this_session"
+    private val MANUALLY_CLAIMED_KEY = "manually_claimed"
     private val MAX_MESSAGES = 50
     private val DEFAULT_DELAY = 2
 
@@ -85,6 +86,7 @@ class MainActivity : AppCompatActivity() {
     private var sentThisSession = 0  // Messages sent this session
     private var confirmedThisSession = 0  // Confirmations received this session
     private var confirmedAtBaselineSave = 0  // Snapshot of confirmedThisSession when baseline balance was saved
+    private var manuallyClaimedCount = 0  // Pending slots reserved by manual confirmation, to discard matching late auto-SMSs
     private val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
     private var isVerifyingBalance = false
     private val verificationTimeoutHandler = Handler(Looper.getMainLooper())
@@ -158,6 +160,7 @@ class MainActivity : AppCompatActivity() {
         confirmedAtBaselineSave = sharedPreferences.getInt(CONFIRMED_AT_BASELINE_KEY, 0)
         confirmedThisSession = sharedPreferences.getInt(CONFIRMED_THIS_SESSION_KEY, 0)
         sentThisSession = sharedPreferences.getInt(SENT_THIS_SESSION_KEY, 0)
+        manuallyClaimedCount = sharedPreferences.getInt(MANUALLY_CLAIMED_KEY, 0)
 
         // Check for month change and ask user if they want to reset counters
         checkMonthChange()
@@ -299,11 +302,13 @@ class MainActivity : AppCompatActivity() {
         sentThisSession = 0
         confirmedThisSession = 0
         confirmedAtBaselineSave = 0
+        manuallyClaimedCount = 0
         sharedPreferences.edit()
             .remove(LAST_BALANCE_KEY)
             .remove(CONFIRMED_AT_BASELINE_KEY)
             .putInt(CONFIRMED_THIS_SESSION_KEY, 0)
             .putInt(SENT_THIS_SESSION_KEY, 0)
+            .putInt(MANUALLY_CLAIMED_KEY, 0)
             .apply()
         refreshDonationStats()
         updatePendingConfirmations()
@@ -483,11 +488,13 @@ class MainActivity : AppCompatActivity() {
             sentThisSession = 0
             confirmedThisSession = 0
             confirmedAtBaselineSave = 0
+            manuallyClaimedCount = 0
             sharedPreferences.edit()
                 .remove(LAST_BALANCE_KEY)
                 .remove(CONFIRMED_AT_BASELINE_KEY)
                 .putInt(CONFIRMED_THIS_SESSION_KEY, 0)
                 .putInt(SENT_THIS_SESSION_KEY, 0)
+                .putInt(MANUALLY_CLAIMED_KEY, 0)
                 .apply()
             updatePendingConfirmations()
             refreshDonationStats()
@@ -731,9 +738,15 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun addDonation(amount: Int) {
-        // Only record if there is an unconfirmed sent message to consume; otherwise this is a
-        // duplicate/late SMS for a donation already claimed by a manual confirmation.
-        if (confirmedThisSession >= sentThisSession) return
+        // If there are pending manual claims, this is a late auto-SMS for a batch already manually
+        // confirmed. Consume the claim and skip the DB write to avoid double-counting.
+        if (manuallyClaimedCount > 0) {
+            manuallyClaimedCount--
+            sharedPreferences.edit().putInt(MANUALLY_CLAIMED_KEY, manuallyClaimedCount).apply()
+            // confirmedThisSession was already pre-incremented by manuallyConfirmPending; no further action needed.
+            updatePendingConfirmations()
+            return
+        }
         val today = dateFormat.format(Calendar.getInstance().time)
         // Increment session confirmation counter and persist so it survives activity recreation
         confirmedThisSession++
@@ -963,10 +976,14 @@ class MainActivity : AppCompatActivity() {
 
     private fun manuallyConfirmPending(count: Int) {
         if (count <= 0) return
-        // Claim the pending count synchronously on the Main thread before the async DB write,
-        // so an automatic confirmation SMS arriving in the interim cannot cause double-counting.
+        // Claim the pending count synchronously: pre-increment confirmedThisSession and register
+        // manual claims so that matching late auto-confirmation SMSs are discarded by addDonation().
         confirmedThisSession += count
-        sharedPreferences.edit().putInt(CONFIRMED_THIS_SESSION_KEY, confirmedThisSession).apply()
+        manuallyClaimedCount += count
+        sharedPreferences.edit()
+            .putInt(CONFIRMED_THIS_SESSION_KEY, confirmedThisSession)
+            .putInt(MANUALLY_CLAIMED_KEY, manuallyClaimedCount)
+            .apply()
         updatePendingConfirmations()
         val amountPesos = count * 10
         val today = dateFormat.format(Calendar.getInstance().time)

--- a/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
@@ -53,6 +53,7 @@ class MainActivity : AppCompatActivity() {
     private val LAST_MONTH_KEY = "last_month"
     private val LAST_BALANCE_KEY = "last_balance"
     private val CONFIRMED_AT_BASELINE_KEY = "confirmed_at_baseline"
+    private val CONFIRMED_THIS_SESSION_KEY = "confirmed_this_session"
     private val MAX_MESSAGES = 50
     private val DEFAULT_DELAY = 2
 
@@ -154,6 +155,7 @@ class MainActivity : AppCompatActivity() {
 
         // Restore persisted baseline snapshot so it stays in sync with LAST_BALANCE_KEY across recreation
         confirmedAtBaselineSave = sharedPreferences.getInt(CONFIRMED_AT_BASELINE_KEY, 0)
+        confirmedThisSession = sharedPreferences.getInt(CONFIRMED_THIS_SESSION_KEY, 0)
 
         // Check for month change and ask user if they want to reset counters
         checkMonthChange()
@@ -298,6 +300,7 @@ class MainActivity : AppCompatActivity() {
         sharedPreferences.edit()
             .remove(LAST_BALANCE_KEY)
             .remove(CONFIRMED_AT_BASELINE_KEY)
+            .putInt(CONFIRMED_THIS_SESSION_KEY, 0)
             .apply()
         refreshDonationStats()
         updatePendingConfirmations()
@@ -478,6 +481,7 @@ class MainActivity : AppCompatActivity() {
             sharedPreferences.edit()
                 .remove(LAST_BALANCE_KEY)
                 .remove(CONFIRMED_AT_BASELINE_KEY)
+                .putInt(CONFIRMED_THIS_SESSION_KEY, 0)
                 .apply()
             updatePendingConfirmations()
             refreshDonationStats()
@@ -722,8 +726,9 @@ class MainActivity : AppCompatActivity() {
 
     private fun addDonation(amount: Int) {
         val today = dateFormat.format(Calendar.getInstance().time)
-        // Increment session confirmation counter
+        // Increment session confirmation counter and persist so it survives activity recreation
         confirmedThisSession++
+        sharedPreferences.edit().putInt(CONFIRMED_THIS_SESSION_KEY, confirmedThisSession).apply()
         updatePendingConfirmations()
         
         CoroutineScope(Dispatchers.IO).launch {
@@ -842,6 +847,12 @@ class MainActivity : AppCompatActivity() {
                                     .setNegativeButton("Cancelar", null)
                                     .show()
                             } else {
+                                // No positive diff: advance baseline to current balance so future verifications start fresh
+                                sharedPreferences.edit()
+                                    .putFloat(LAST_BALANCE_KEY, balance.toFloat())
+                                    .putInt(CONFIRMED_AT_BASELINE_KEY, confirmedThisSession)
+                                    .apply()
+                                confirmedAtBaselineSave = confirmedThisSession
                                 Toast.makeText(this, "ℹ️ No se detectaron donaciones por diferencia de saldo", Toast.LENGTH_LONG).show()
                             }
                         }
@@ -956,6 +967,7 @@ class MainActivity : AppCompatActivity() {
             }
             withContext(Dispatchers.Main) {
                 confirmedThisSession += count
+                sharedPreferences.edit().putInt(CONFIRMED_THIS_SESSION_KEY, confirmedThisSession).apply()
                 updatePendingConfirmations()
                 refreshDonationStats()
                 Toast.makeText(this@MainActivity, "✅ $count donación(es) confirmadas manualmente (+\$${amountPesos})", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
@@ -456,8 +456,8 @@ class MainActivity : AppCompatActivity() {
         dialog.setMessage("Esto reiniciará los contadores de mensajes enviados en esta sesión y limpiará el saldo mostrado.\n\n⚠️ El historial de donaciones NO se borrará.")
         dialog.setPositiveButton("Sí, reiniciar") { _, _ ->
             // Clear response count
-            val sharedPreferences = getSharedPreferences("donation_prefs", Context.MODE_PRIVATE)
-            sharedPreferences.edit().apply {
+            val donationPrefs = getSharedPreferences("donation_prefs", Context.MODE_PRIVATE)
+            donationPrefs.edit().apply {
                 putInt("response_count", 0)
                 apply()
             }
@@ -829,14 +829,15 @@ class MainActivity : AppCompatActivity() {
                                     .setTitle("✅ Donaciones detectadas por saldo")
                                     .setMessage("Saldo anterior: ${"%.0f".format(previousBalance)}\$\nSaldo actual: ${"%.0f".format(balance)}\$\n\nDiferencia: ${"%.0f".format(diff)}\$ = $donatedMessages mensajes$alreadyConfirmedInfo\n\n¿Confirmar las donaciones pendientes en el historial?")
                                     .setPositiveButton("Confirmar $pendingToConfirm mensajes") { _, _ ->
-                                        // Advance baseline so the same diff isn't re-offered after restart
-                                        val newBaseline = confirmedThisSession + pendingToConfirm
+                                        // Recalculate in case auto-confirmations arrived while dialog was open
+                                        val actualPending = (donatedMessages - (confirmedThisSession - confirmedAtBaselineSave)).coerceAtLeast(0)
+                                        val newBaseline = confirmedThisSession + actualPending
                                         sharedPreferences.edit()
                                             .putFloat(LAST_BALANCE_KEY, balance.toFloat())
                                             .putInt(CONFIRMED_AT_BASELINE_KEY, newBaseline)
                                             .apply()
                                         confirmedAtBaselineSave = newBaseline
-                                        manuallyConfirmPending(pendingToConfirm)
+                                        manuallyConfirmPending(actualPending)
                                     }
                                     .setNegativeButton("Cancelar", null)
                                     .show()

--- a/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
@@ -290,7 +290,7 @@ class MainActivity : AppCompatActivity() {
         // Reset session counters
         sentThisSession = 0
         confirmedThisSession = 0
-        // Note: Database records are historical and not reset
+        confirmedAtBaselineSave = 0
         refreshDonationStats()
         updatePendingConfirmations()
         Toast.makeText(this, "Contadores reiniciados", Toast.LENGTH_SHORT).show()
@@ -466,9 +466,8 @@ class MainActivity : AppCompatActivity() {
             // Reset session counters
             sentThisSession = 0
             confirmedThisSession = 0
+            confirmedAtBaselineSave = 0
             updatePendingConfirmations()
-            
-            // Refresh donation stats from database
             refreshDonationStats()
             
             // Hide progress UI
@@ -815,6 +814,9 @@ class MainActivity : AppCompatActivity() {
                                     .setTitle("✅ Donaciones detectadas por saldo")
                                     .setMessage("Saldo anterior: ${"%.0f".format(previousBalance)}\$\nSaldo actual: ${"%.0f".format(balance)}\$\n\nDiferencia: ${"%.0f".format(diff)}\$ = $donatedMessages mensajes$alreadyConfirmedInfo\n\n¿Confirmar las donaciones pendientes en el historial?")
                                     .setPositiveButton("Confirmar $pendingToConfirm mensajes") { _, _ ->
+                                        // Advance baseline so the same diff isn't re-offered after restart
+                                        sharedPreferences.edit().putFloat(LAST_BALANCE_KEY, balance.toFloat()).apply()
+                                        confirmedAtBaselineSave = confirmedThisSession + pendingToConfirm
                                         manuallyConfirmPending(pendingToConfirm)
                                     }
                                     .setNegativeButton("Cancelar", null)

--- a/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
@@ -731,6 +731,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun addDonation(amount: Int) {
+        // Only record if there is an unconfirmed sent message to consume; otherwise this is a
+        // duplicate/late SMS for a donation already claimed by a manual confirmation.
+        if (confirmedThisSession >= sentThisSession) return
         val today = dateFormat.format(Calendar.getInstance().time)
         // Increment session confirmation counter and persist so it survives activity recreation
         confirmedThisSession++

--- a/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
@@ -960,6 +960,11 @@ class MainActivity : AppCompatActivity() {
 
     private fun manuallyConfirmPending(count: Int) {
         if (count <= 0) return
+        // Claim the pending count synchronously on the Main thread before the async DB write,
+        // so an automatic confirmation SMS arriving in the interim cannot cause double-counting.
+        confirmedThisSession += count
+        sharedPreferences.edit().putInt(CONFIRMED_THIS_SESSION_KEY, confirmedThisSession).apply()
+        updatePendingConfirmations()
         val amountPesos = count * 10
         val today = dateFormat.format(Calendar.getInstance().time)
         CoroutineScope(Dispatchers.IO).launch {
@@ -972,9 +977,6 @@ class MainActivity : AppCompatActivity() {
                 )
             }
             withContext(Dispatchers.Main) {
-                confirmedThisSession += count
-                sharedPreferences.edit().putInt(CONFIRMED_THIS_SESSION_KEY, confirmedThisSession).apply()
-                updatePendingConfirmations()
                 refreshDonationStats()
                 Toast.makeText(this@MainActivity, "✅ $count donación(es) confirmadas manualmente (+\$${amountPesos})", Toast.LENGTH_SHORT).show()
             }

--- a/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
@@ -802,11 +802,15 @@ class MainActivity : AppCompatActivity() {
                         val donatedMessages = (diff / 10).toInt()
                         runOnUiThread {
                             if (diff > 0) {
+                                val pendingToConfirm = (donatedMessages - confirmedThisSession).coerceAtLeast(0)
+                                val alreadyConfirmedInfo = if (confirmedThisSession > 0)
+                                    "\nYa confirmados automáticamente: $confirmedThisSession mensajes\nA agregar ahora: $pendingToConfirm mensajes"
+                                else ""
                                 android.app.AlertDialog.Builder(this)
                                     .setTitle("✅ Donaciones detectadas por saldo")
-                                    .setMessage("Saldo anterior: ${"%.0f".format(previousBalance)}\$\nSaldo actual: ${"%.0f".format(balance)}\$\n\nDiferencia: ${"%.0f".format(diff)}\$ = $donatedMessages mensajes\n\n¿Confirmar estas donaciones en el historial?")
-                                    .setPositiveButton("Confirmar $donatedMessages mensajes") { _, _ ->
-                                        manuallyConfirmPending(donatedMessages)
+                                    .setMessage("Saldo anterior: ${"%.0f".format(previousBalance)}\$\nSaldo actual: ${"%.0f".format(balance)}\$\n\nDiferencia: ${"%.0f".format(diff)}\$ = $donatedMessages mensajes$alreadyConfirmedInfo\n\n¿Confirmar las donaciones pendientes en el historial?")
+                                    .setPositiveButton("Confirmar $pendingToConfirm mensajes") { _, _ ->
+                                        manuallyConfirmPending(pendingToConfirm)
                                     }
                                     .setNegativeButton("Cancelar", null)
                                     .show()

--- a/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
+++ b/app/src/main/java/uy/roar/donadorautomatico/MainActivity.kt
@@ -81,6 +81,7 @@ class MainActivity : AppCompatActivity() {
     private val database by lazy { DonationDatabase.getDatabase(this) }
     private var sentThisSession = 0  // Messages sent this session
     private var confirmedThisSession = 0  // Confirmations received this session
+    private var confirmedAtBaselineSave = 0  // Snapshot of confirmedThisSession when baseline balance was saved
     private val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
     private var isVerifyingBalance = false
     private val verificationTimeoutHandler = Handler(Looper.getMainLooper())
@@ -789,9 +790,12 @@ class MainActivity : AppCompatActivity() {
                 val calculatedCount = (balance / 10).toInt()
                 val numericPartFinal = numericPart
 
-                // Save the current balance for future verification comparisons
+                // Save the current balance for future verification comparisons (only when establishing a new baseline, not during verification)
                 val previousBalance = sharedPreferences.getFloat(LAST_BALANCE_KEY, -1f)
-                sharedPreferences.edit().putFloat(LAST_BALANCE_KEY, balance.toFloat()).apply()
+                if (!isVerifyingBalance) {
+                    sharedPreferences.edit().putFloat(LAST_BALANCE_KEY, balance.toFloat()).apply()
+                    confirmedAtBaselineSave = confirmedThisSession
+                }
 
                 // If in verification mode, cancel the timeout and compare with previous balance
                 if (isVerifyingBalance) {
@@ -802,9 +806,10 @@ class MainActivity : AppCompatActivity() {
                         val donatedMessages = (diff / 10).toInt()
                         runOnUiThread {
                             if (diff > 0) {
-                                val pendingToConfirm = (donatedMessages - confirmedThisSession).coerceAtLeast(0)
-                                val alreadyConfirmedInfo = if (confirmedThisSession > 0)
-                                    "\nYa confirmados automáticamente: $confirmedThisSession mensajes\nA agregar ahora: $pendingToConfirm mensajes"
+                                val confirmedSinceBaseline = confirmedThisSession - confirmedAtBaselineSave
+                                val pendingToConfirm = (donatedMessages - confirmedSinceBaseline).coerceAtLeast(0)
+                                val alreadyConfirmedInfo = if (confirmedSinceBaseline > 0)
+                                    "\nYa confirmados automáticamente: $confirmedSinceBaseline mensajes\nA agregar ahora: $pendingToConfirm mensajes"
                                 else ""
                                 android.app.AlertDialog.Builder(this)
                                     .setTitle("✅ Donaciones detectadas por saldo")


### PR DESCRIPTION
## Problema

Al usar **Verificar por saldo** para confirmar donaciones pendientes, el cálculo era incorrecto: la diferencia de crédito detectada representa el **total** de mensajes enviados, pero parte de ellos ya habían sido confirmados automáticamente vía SMS ("Gracias por colaborar").

### Ejemplo del bug
- Se envían 10 mensajes → `sentThisSession = 10`
- Llegan 8 confirmaciones automáticas → `confirmedThisSession = 8`, DB tiene 80$
- El usuario usa "Verificar por saldo" → diferencia = 100$ = 10 mensajes
- Se llama `manuallyConfirmPending(10)` → agrega 100$ al historial
- **Resultado:** DB queda con 180$ en vez de 100$

## Solución

Se resta `confirmedThisSession` al total detectado por diferencia de saldo antes de llamar a `manuallyConfirmPending()`:

```kotlin
val pendingToConfirm = (donatedMessages - confirmedThisSession).coerceAtLeast(0)
```

También se actualiza el mensaje del diálogo para mostrar el desglose completo cuando hay confirmaciones previas (total detectado / ya confirmados / a agregar ahora).